### PR TITLE
Migrate to new api

### DIFF
--- a/OJPP.js
+++ b/OJPP.js
@@ -93,7 +93,7 @@ async function zahtevaj_relacijo_vsi_peroni(start, cilj) {
  * @returns Array of current buses
  */
 async function zahtevaj_buse() {
-    return fp(`https://ojpp.si/api/vehicle_locations`);
+    return fp(`https://api.beta.brezavta.si/vehicles/locations`);
 }
 
 NA_POSTAJALISCU_THRESHOLD = 100; // metres
@@ -304,13 +304,13 @@ var trips;
  * @returns Nothing
  */
 async function godusModus(automatic=false) {
-    buses = (await zahtevaj_buse())["features"];
-    buses = buses.filter(bus => bus.properties.operator_name !== "Javno podjetje Ljubljanski potniški promet d.o.o."); // Odstranimo LPP, ker imamo zanje svoj gumb (LPP), ki pravilno prikaze vec info (registrska, hitrost ...). Ministrski podatki vsebujejo le null, null. Strålande null.
+    buses = (await zahtevaj_buse());
+    buses = buses.filter(bus => bus.vehicle.operator_name !== "Ljubljanski Potniški Promet"); // Odstranimo LPP, ker imamo zanje svoj gumb (LPP), ki pravilno prikaze vec info (registrska, hitrost ...). Ministrski podatki vsebujejo le null, null. Strålande null.
 
-    if(trips) buses = buses.filter(bus => trips.some(trip => trip.trip_id === bus.properties.trip_id));
+    //if(trips) buses = buses.filter(bus => trips.some(trip => trip.trip_id === bus.properties.trip_id));
     for(let b of buses) {
-        let id = b.properties.vehicle_id;
-        busi[id] = {...busi[id], ...b.properties, long: b.geometry.coordinates[0], lat: b.geometry.coordinates[1]};
+        let id = b.vehicle.id;
+        busi[id] = {...busi[id], ...b.vehicle, ...b};
     }
 
     izrisi_OJPP(busi, automatic);
@@ -430,7 +430,7 @@ async function refresh(automatic=false) {
 function centerCurrentBus(){
     if (currentBusId){
         let currentBus = busi[currentBusId];
-        let currentBusCoordinates = [currentBus.lat, currentBus.long];
+        let currentBusCoordinates = [currentBus.lat, currentBus.lon];
         mymap.flyTo(currentBusCoordinates);
     }
 }

--- a/OJPP.js
+++ b/OJPP.js
@@ -539,10 +539,24 @@ async function tripsOnStop(stop_id, period){
 
     //return trips;
     //Log just trips that are comming in the next hour
-    trips  = (trips.filter(trip => (new getTimeAsDate(seconds2time(trip?.departure_realtime) ?? "-24:01:01") - new Date()) < period*60*1000 && (new getTimeAsDate(seconds2time(trip?.departure_realtime) ?? "-24:01:01") - new Date()) > 0));
+    trips  = (trips.filter(trip => (new getTimeAsDate(seconds2time(trip?.departure_realtime) ?? "-24:01:01") - new Date()) < period*60*1000 && (new getTimeAsDate(seconds2time(trip?.departure_realtime) ?? "-24:01:01") - new Date()) > -3*60*1000));
     console.log(trips);
     return trips;
 
+}
+
+/**
+ * Returns vehicle.id from trip_id
+ * @param {*} tripId trip_id
+ */
+function tripId2busId(tripId) {
+    console.log("tripId2busId", tripId);
+    // busi is a dictionary of dictionaries, where the key is the vehicle.id. We need to find the vehicle.id from the trip_id.
+    for(let busId in busi) {
+        if(busi[busId].trip_id === tripId) {
+            return busId;
+        }
+    }
 }
 
 /**
@@ -590,25 +604,17 @@ async function displayTripsOnStop(stopid, period = 60){
         }
         td.style.paddingRight = "30px";
         tr.appendChild(td);
+        tr.dataset.tripid = t.trip_id;
+        tr.addEventListener("click", function(e) {
+            // only if not a
+            if(e.target.tagName !== "A") m2[tripId2busId(t.trip_id)]?.openPopup();
+        });
 
-        if(t?.vehicle?.id) {
+        if(t?.realtime){
             let span = document.createElement("span");
             span.classList.add("material-symbols-outlined");
             span.classList.add('busLive');
             span.innerText = "sensors";
-            td.appendChild(span);
-            tr.dataset.busid = t.vehicle.id;
-            tr.classList.add("tripLive");
-            tr.addEventListener("click", function(e) {
-                // only if not a
-                if(e.target.tagName !== "A") m2[t.vehicle.id]?.openPopup();
-            });
-        }
-        if(t?.realtime){
-            let span = document.createElement("span");
-            //span.classList.add("material-symbols-outlined");
-            span.classList.add('busLive');
-            span.innerText = "We have realtime info, ampak ne vem, kako ga polinkati z busom.";
             td.appendChild(span);
             //tr.dataset.busid = t.vehicle.id;
             tr.classList.add("tripLive");

--- a/busi-offline.js
+++ b/busi-offline.js
@@ -1,5 +1,5 @@
 {
-	"version": 7,
+	"version": 8,
 	"fileList": [
 		"index.html",
 		"style.css",

--- a/index.html
+++ b/index.html
@@ -111,6 +111,14 @@
 		</div>
 	</div>
 
+	<div class="toast_message no" id="toast_message">
+		<div class="center" style="width:80%">
+			<span class="material-symbols-outlined" style="left:50%; padding-top: 20px; font-size:1.5rem">breakfast_dining</span><br>
+			<p>Toast!</p>
+		</div>
+	</div>
+
+
 
 
 	<div class = "tool_container">

--- a/style.css
+++ b/style.css
@@ -11,6 +11,7 @@
     --color-warning: #B67352;
     --color-info: grey;   
     --color-theme-second: rgba(204, 204, 204, 0.69);
+    --color-toast: #ecca9e;
 
     overscroll-behavior: none;
 }
@@ -27,6 +28,7 @@
 
     --color-warning: #f3986a !important;
     --color-info: #dadada !important;
+    --color-toast: #925507 !important;
     }
 
     body{
@@ -149,6 +151,20 @@ button:not(.zamudas button) {
 .offline_warning{
     position: fixed;
     background-color: var(--color-theme);
+    border-radius: 1.5rem;
+    box-shadow: 0 0 20px 0 var(--color-boxshadow);
+    opacity:0.95;
+    bottom: 150px;
+    left:5vw;
+    width:90vw;
+    height: 130px;
+    z-index: 100;
+}
+
+.toast_message{
+    position: fixed;
+    background-color: #ecca9e;
+    color: #925507;
     border-radius: 1.5rem;
     box-shadow: 0 0 20px 0 var(--color-boxshadow);
     opacity:0.95;

--- a/ui.js
+++ b/ui.js
@@ -237,24 +237,24 @@ function prikaziPostajiNaZemljevidu(imePostaje) {
     idsPostaj = postajalisca[imePostaje];
     // get object from data_postajalisca which has the same id as the one in idsPostaj
     for (let i = 0; i < idsPostaj.length; i++) {
-        let postaja = data_postajalisca.find(p => p.properties.id == idsPostaj[i]);
+        let postaja = data_postajalisca.find(p => p.gtfs_id == idsPostaj[i]);
         console.log(postaja);
         if (postaja) {
-            let lat = postaja.geometry.coordinates[1];
-            let lon = postaja.geometry.coordinates[0];
+            let lat = postaja.lat;
+            let lon = postaja.lon;
             // Create a new marker with icon peron
-            let marker = L.marker([postaja.geometry.coordinates[1], postaja.geometry.coordinates[0]], {icon: peronIcon}).addTo(mymap);
+            let marker = L.marker([lat, lon], {icon: peronIcon}).addTo(mymap);
             let menuElement = document.getElementById('menu');
 
             //On popup open
             marker.on('popupopen', function() {
-                selectedStop = postaja.properties.id;
-                poglejOdhodeSTePostaje(postaja.properties.id);
+                selectedStop = postaja.gtfs_id;
+                poglejOdhodeSTePostaje(postaja.gtfs_id);
                 menuClose();
                 menuElement.classList.add('closed');
                 toggleTimetable();
 
-                document.getElementById('timetable_title').innerHTML = postaja.properties.name;
+                document.getElementById('timetable_title').innerHTML = postaja.name;
                 document.getElementById('timetable_warning').classList.add("no");
             });
 
@@ -265,7 +265,7 @@ function prikaziPostajiNaZemljevidu(imePostaje) {
                 menuElement.classList.add('closed');
             });
 
-            let vsebina = `<span style="color:var(--color-primary)">${postaja.properties.name}</span>`;
+            let vsebina = `<span style="color:var(--color-primary)">${postaja.name}</span>`;
             marker.bindPopup(vsebina);
             // Fly to
             mymap.flyTo([lat, lon], 18.5, {duration: 0.5});
@@ -309,9 +309,14 @@ function toggleMenu() {
 }
 
 //Auto refresh every 20 seconds
-setInterval(function(){
+refresher = setInterval(function(){
     refresh(automatic=true);
 }, 20000);
+
+// Stop auto-refreshing after 5 minutes of inactivity
+setTimeout(function(){
+    clearInterval(refresher);
+}, 5*60*1000);
 
 //Handle offline situation
 window.addEventListener('offline', function(event){

--- a/zemljevid.js
+++ b/zemljevid.js
@@ -261,7 +261,7 @@ function izrisi_OJPP(busi, automatic=false) {
 	d = new Date(); // Uporabimo kasneje za skrivanje starih busov
 
     if(!automatic && Object.keys(busi).length === 0) {
-        alert("Ni takih busov, vsaj ne na OJPP");
+        //alert("Ni takih busov, vsaj ne na OJPP");
         //Get element with id 'non_existing'
         var errorPopup = document.getElementById("non_existing");
 
@@ -353,7 +353,7 @@ function izrisi_OJPP(busi, automatic=false) {
             vsebina += `<br><span class="bus_info"><b style='user-select: text'>${plate}</b></span>`;
             vsebina += `<br><span class="bus_info">Prevoznik: ${odg?.["operator_name"]}</span>`;
 
-            vsebina += (`<div class="popup_zamuda" style="width:fit-content;"><span class='popup_zamuda_button' onclick='izpisi_zamudo2(this,"${vozilo}")' style="width:fit-content; margin-left:-10px">Kolikšna je zamuda?</span></div>`); //ZAMUDA
+            vsebina += (`<div class="popup_zamuda" style="width:fit-content;"><span class='popup_zamuda_button' onclick='izpisi_zamudo2(this,"${vozilo}")' style="width:fit-content; margin-left:-10px; opacity: 0.1" disabled>Zamude busov trenutno niso prikazane.</span></div>`); //ZAMUDA
 
             vsebina +=` 
                 </div>
@@ -435,4 +435,23 @@ async function iskalnikBusId() {
     //Wait for busses to load
     await godusModus();
     m2[zadnjiIskaniBusId].openPopup();
+}
+
+
+var toastTT1, toastTT2, toastTT3;
+function toast(message) {
+    clearTimeout(toastTT1);
+    clearTimeout(toastTT2);
+    clearTimeout(toastTT3);
+    let toast = document.getElementById("toast_message");
+    toast.getElementsByTagName("p")[0].innerText = message;
+
+    //Increase opacity to 0.8 for 3 seconds with animation
+    //Also remove the "no" class so display: none is removed and then add it back after 3 seconds
+    toast.style.opacity = 0;
+    toast.style.transition = "opacity 1s ease-in-out";
+    toast.classList.remove("no");
+    toastTT1 = setTimeout(function(){toast.style.opacity = 0.8;}, 100);
+    toastTT2 = setTimeout(function(){toast.style.opacity = 0;}, 3000);
+    toastTT3 = setTimeout(function(){toast.classList.add("no");}, 4000);
 }

--- a/zemljevid.js
+++ b/zemljevid.js
@@ -245,6 +245,8 @@ function brisiMarkerje() {
     busi = {};
 }
 
+lastZoom = undefined;
+
 
 /**
  * Add buses to map
@@ -363,8 +365,9 @@ function izrisi_OJPP(busi, automatic=false) {
                 document.getElementById('delay_container').classList.add('no');
                 menuClose();
               
+                lastZoom = mymap.getZoom();
                 //Zoom in on bus location
-                mymap.flyTo([odg["lat"],odg["lon"]], 15, {duration: 0.5});
+                mymap.flyTo([odg["lat"],odg["lon"]], Math.max(lastZoom, 15), {duration: 0.5});
                 currentBusId = odg["id"];
 
             });
@@ -372,7 +375,7 @@ function izrisi_OJPP(busi, automatic=false) {
             m2[vozilo].on('popupclose', function() {
                 hideDelays();
                 //Zoom out
-                mymap.flyTo([odg["lat"],odg["lon"]], 12, {duration: 0.5});
+                mymap.flyTo([odg["lat"],odg["lon"]], Math.max(lastZoom, 12), {duration: 0.5});
                 currentBusId = 0;
                 document.getElementById("timetable_no_line").classList.remove("no");
             });

--- a/zemljevid.js
+++ b/zemljevid.js
@@ -285,6 +285,7 @@ function izrisi_OJPP(busi, automatic=false) {
         var bear = odg["heading"];
 
         if(x === undefined || y === undefined) {
+            alert(`A se to kdaj zgodi? Bus ${vozilo} nima koordinat: ${x}, ${y}`);
             // Bus nima koordinat, le izpišemo registrsko
             log.innerText += (`\n${vozilo}: ${odg["plate"]}, ${odg["route_name"]}, urnik: ${odg["time_departure"]}; model: ${odg?.["model"]?.["name"]}`);
             continue;
@@ -314,7 +315,9 @@ function izrisi_OJPP(busi, automatic=false) {
         
         if (!document.getElementById("prikazujStareBuse").checked && d - busTstamp > ZAPADLOST) {
             mymap.removeLayer(m2[vozilo]);
+            mymap.removeLayer(m3[vozilo]);
             delete m2[vozilo];
+            delete m3[vozilo];
             continue;
         }
         // Konec preverjanja za skrivanje starih busov.

--- a/zemljevid.js
+++ b/zemljevid.js
@@ -328,7 +328,7 @@ function izrisi_OJPP(busi, automatic=false) {
             timeDeparture = odg?.["time_departure"] ?? "";
             timeArrival = odg?.["prihodNaCilj"] ?? "";
             plate = odg?.["plate"] ?? "";
-            plate = isNaN(plate[0]) ? plate : `${plate} (morda to ni prava registrska)`;
+            plate = isNaN(plate[0]) ? `${plate.substr(0, 2)} ${plate.substr(2)}` : `${plate} (morda to ni prava registrska)`;
 
 
             vsebina = "";
@@ -348,6 +348,7 @@ function izrisi_OJPP(busi, automatic=false) {
                 
             }
             vsebina += `<br><span class="bus_info"><b style='user-select: text'>${plate}</b></span>`;
+            vsebina += `<br><span class="bus_info">Prevoznik: ${odg?.["operator_name"]}</span>`;
 
             vsebina += (`<div class="popup_zamuda" style="width:fit-content;"><span class='popup_zamuda_button' onclick='izpisi_zamudo2(this,${vozilo})' style="width:fit-content; margin-left:-10px">Kolikšna je zamuda?</span></div>`); //ZAMUDA
 

--- a/zemljevid.js
+++ b/zemljevid.js
@@ -353,7 +353,7 @@ function izrisi_OJPP(busi, automatic=false) {
             vsebina += `<br><span class="bus_info"><b style='user-select: text'>${plate}</b></span>`;
             vsebina += `<br><span class="bus_info">Prevoznik: ${odg?.["operator_name"]}</span>`;
 
-            vsebina += (`<div class="popup_zamuda" style="width:fit-content;"><span class='popup_zamuda_button' onclick='izpisi_zamudo2(this,${vozilo})' style="width:fit-content; margin-left:-10px">Kolikšna je zamuda?</span></div>`); //ZAMUDA
+            vsebina += (`<div class="popup_zamuda" style="width:fit-content;"><span class='popup_zamuda_button' onclick='izpisi_zamudo2(this,"${vozilo}")' style="width:fit-content; margin-left:-10px">Kolikšna je zamuda?</span></div>`); //ZAMUDA
 
             vsebina +=` 
                 </div>


### PR DESCRIPTION
This PR changes the API source from deprecated `ojpp.si` to novel (and recommended) `api.beta.brezavta.si`.
Most of basic functionality should by this be fixed.

Because new API uses different station IDs, this PR also migrates old favourites to new IDs. It notifies the user with a beautiful toast ~sandwich~ message 🍞

Also, it shows live tracking on schedules of favourite relations.