### PR TITLE
Bugfixes, denote train stations, keyboard accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ Spletna aplikacija [Busi](https://zznidar.github.io/busi/) omogoča pregled nad 
 * zemljevid s potjo posameznega avtobusa
 * **lokacije** vseh avtobusov  
 
-<img src="images/3.png" alt="Spet zamuja? Preveri zamude!" width="30%">
-<img src="images/2.png" alt="Kdaj bo naslednji? Urnik za izbrano relacijo!" width="30%">
-<img src="images/1.png" alt="Sledi avtobusom po vsej Sloveniji!" width="30%">
+<img src="images/3.png" alt="Spet zamuja? Preveri zamude!" width="30%"> <img src="images/2.png" alt="Kdaj bo naslednji? Urnik za izbrano relacijo!" width="30%"> <img src="images/1.png" alt="Sledi avtobusom po vsej Sloveniji!" width="30%">
 
 
 ## Vir podatkov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
-# Busi
-Prikazovalnik avtobusov in njihovih zamud.
+# Busi <img src="graphics/bus_icon.png" alt="Busi logo" width="40px">
+## Prikazovalnik avtobusov in njihovih zamud.  
+<!-- <img src="graphics/bus_icon.png" alt="Busi logo" width="100px">   -->
+
+Spletna aplikacija [Busi](https://zznidar.github.io/busi/) omogoča pregled nad vsemi slovenskimi avtobusi znotraj IJPP. Uporabniku so prikazane naslednje informacije:  
+* **zamude** posameznih avtobusov
+* real-time **napovedi prihodov**
+* zemljevid s potjo posameznega avtobusa
+* **lokacije** vseh avtobusov  
+
+<img src="images/3.png" alt="Spet zamuja? Preveri zamude!" width="30%">
+<img src="images/2.png" alt="Kdaj bo naslednji? Urnik za izbrano relacijo!" width="30%">
+<img src="images/1.png" alt="Sledi avtobusom po vsej Sloveniji!" width="30%">
 
 
 ## Vir podatkov

--- a/busi-offline.js
+++ b/busi-offline.js
@@ -1,5 +1,5 @@
 {
-	"version": "2.1",
+	"version": "2.2",
 	"fileList": [
 		"index.html",
 		"style.css",

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,23 @@
 # Changelog
 All versions of releases will be documented here. Versions before 1.0 relase are not documented here as changelog was not established then. 
 
+## v2.2
+Release date: 2025-08-20
+### What is new?
+**🌟 Improvements**  
+* Use modern search field when adding new _Pribljubljene relacije_
+* Use arrow keys and Enter to select search results on computer #14
+* Better and faster UX when switching between tabs
+* _Priljubljene relacije_ now opens automatically on start
+
+**🐛 Bug fixes**  
+* Prevent automatic map moving when selecting a bus stop if vehicle locations refresh #13
+* Fix NaN duration if it extends past midnight #17
+
+**🔁 Changes**  
+* Train stations 🚂 are now separated from bus stations. This should make usage more straight-forward (and avoid confusion why there are no buses on Ljubljana)
+
+
 ## v2.1
 Release date: 2025-04-20
 ### What is new?

--- a/index.html
+++ b/index.html
@@ -56,8 +56,11 @@
 
 	<div class="search_container no" id="search_container">
 		<div style="margin-top:-2px">
-			<input type="text" id="search_field" class="search_field" placeholder="Išči po postajah">
-			<span class="material-symbols-outlined" id="search_logo">search</span>
+			<div style="display: flex; align-items: center;">
+				<label id="label_search_field" for="search_field" class="no center">&lt;- Vstopna postaja</label>
+				<input type="text" id="search_field" class="search_field" placeholder="Išči po postajah">
+				<span class="material-symbols-outlined" id="search_logo">search</span>
+			</div>
 			<div id="search_results_container">
 				<ul id="search_results">
 				</ul>
@@ -154,7 +157,7 @@
 			<span class="tool_item" style="left:37.5%">Vozni red</span>
 
 			<span class="material-symbols-outlined tool_icon" style="left: 62.5%;"
-				onclick="toggleSearch()">search</span>
+				onclick="setLabel(''); searchSelectionType='search'; toggleSearch()">search</span>
 			<span class="tool_item" style="left:62.5%">Iskanje</span>
 
 			<!-- <span class="material-symbols-outlined tool_icon" style="left: 62.5%;" onclick="trips = undefined; showBuses()">directions_bus</span>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 	<div class="search_container no" id="search_container">
 		<div style="margin-top:-2px">
 			<div style="display: flex; align-items: center;">
-				<label id="label_search_field" for="search_field" class="no center">&lt;- Vstopna postaja</label>
+				<label id="label_search_field" for="search_field" class="no center" onclick="labelClick()">&lt;- Vstopna postaja</label>
 				<input type="text" id="search_field" class="search_field" placeholder="Išči po postajah">
 				<span class="material-symbols-outlined" id="search_logo">search</span>
 			</div>

--- a/scripts/api_calls.js
+++ b/scripts/api_calls.js
@@ -70,7 +70,8 @@ async function requestAllBusStops() {
     for (let p of busStopsData) {
         if (!p.gtfs_id.startsWith("IJPP:")) continue;
         let name = p.name;
-        if(name === "Ljubljana") name = "Ljubljana ŽP";
+        //if(name === "Ljubljana") name = "Ljubljana ŽP";
+        if(p?.type === "RAIL") name += " 🚂"
         busStops?.[name]?.push(p.gtfs_id) ?? (busStops[name] = [p.gtfs_id]);
     }
     return;

--- a/scripts/api_calls.js
+++ b/scripts/api_calls.js
@@ -70,6 +70,7 @@ async function requestAllBusStops() {
     for (let p of busStopsData) {
         if (!p.gtfs_id.startsWith("IJPP:")) continue;
         let name = p.name;
+        if(name === "Ljubljana") name = "Ljubljana ŽP";
         busStops?.[name]?.push(p.gtfs_id) ?? (busStops[name] = [p.gtfs_id]);
     }
     return;

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -343,7 +343,7 @@ function menuClose() {
     setTimeout(function() {
         var element = document.getElementById('menu');
         window.scrollTo({ top: 0, behavior: 'smooth' });
-    }, 300); // Adjust the delay (in milliseconds) to make it slower
+    }, 0); // Adjust the delay (in milliseconds) to make it slower
 }
 
 /**
@@ -353,7 +353,7 @@ function menuOpen() {
     setTimeout(function() {
         var element = document.getElementById('menu');
         element.scrollIntoView({ behavior: "smooth", block: "start", inline: "nearest" });
-    }, 300); // Adjust the delay (in milliseconds) to make it slower
+    }, 0); // Adjust the delay (in milliseconds) to make it slower
 }
 
 
@@ -385,16 +385,17 @@ function toggleFavorite() {
 
     //If favorite is visible, close menus, change visibilites and toggle menu
     if (elementFavorite.classList.contains("no")) {
-        if (!elementMenu.classList.contains("closed")) {
-            menuClose();
+        //if (!elementMenu.classList.contains("closed")) {
+        if (true) {
+            //menuClose();
+            elementTimetable.classList.add("no");
+            elementDelay.classList.add("no");
             setTimeout(function() {
                 elementFavorite.classList.remove("no");
-                elementTimetable.classList.add("no");
-                elementDelay.classList.add("no");
-            }, 800);
+            }, 100);
             setTimeout(() => {
                 menuOpen();
-            }, 1000);
+            }, 0);
         }
         else {
             elementFavorite.classList.remove("no");
@@ -402,7 +403,7 @@ function toggleFavorite() {
             elementDelay.classList.add("no");
             setTimeout(() => {
                 menuOpen();
-            }, 100);
+            }, 0);
         }
         elementMenu.classList.remove("closed");
 
@@ -426,20 +427,21 @@ function toggleTimetable() {
 
     //If favorite is visible, close menus, change visibilites and toggle menu
     if (elementTimetable.classList.contains("no")) {
-        if (!elementMenu.classList.contains("closed")) {
-            menuClose();
+        //if (!elementMenu.classList.contains("closed")) {
+        if (true) {
+            //menuClose();
+            elementFavorite.classList.add("no");
             setTimeout(() => {
                 elementTimetable.classList.remove("no");
-                elementFavorite.classList.add("no");
 
                 if (delayContent.innerHTML != '\n\t\t\t') {
                     elementDelay.classList.remove("no");
                 }
 
-            }, 800);
+            }, 100);
             setTimeout(() => {
                 menuOpen();
-            }, 1000);
+            }, 0);
         }
         else {
             elementTimetable.classList.remove("no");
@@ -449,7 +451,7 @@ function toggleTimetable() {
             }
             setTimeout(() => {
                 menuOpen();
-            }, 100);
+            }, 0);
         }
         elementMenu.classList.remove("closed");
 
@@ -543,7 +545,7 @@ SEARCH_RESULTS.addEventListener("click", function(e) {
 /**
  * Handle keyboard selection of search results
  */
-updownselectindex = 0;
+updownselectindex = -1;
 function updownselect(e) {
     console.log("updownselect: ", e);
     let shownResults = document.getElementById("search_results").getElementsByTagName("li");
@@ -561,7 +563,7 @@ function updownselect(e) {
             shownResults[updownselectindex]?.click();
             break;
         default:
-            updownselectindex = 0;
+            updownselectindex = -1;
             //updownselectindex = updownselectindex% shownResults.length;
     }
     shownResults[updownselectindex]?.classList.add("selected");

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -340,20 +340,15 @@ function closeBusContainer(){
  * Function to close the menu/scrollable site container
  */
 function menuClose() {
-    setTimeout(function() {
-        var element = document.getElementById('menu');
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-    }, 0); // Adjust the delay (in milliseconds) to make it slower
+    window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
 /**
  * Function to open the menu/scrollable site container
  */
 function menuOpen() {
-    setTimeout(function() {
-        var element = document.getElementById('menu');
-        element.scrollIntoView({ behavior: "smooth", block: "start", inline: "nearest" });
-    }, 0); // Adjust the delay (in milliseconds) to make it slower
+    var element = document.getElementById('menu');
+    element.scrollIntoView({ behavior: "smooth", block: "start", inline: "nearest" });
 }
 
 
@@ -385,28 +380,14 @@ function toggleFavorite() {
 
     //If favorite is visible, close menus, change visibilites and toggle menu
     if (elementFavorite.classList.contains("no")) {
-        //if (!elementMenu.classList.contains("closed")) {
-        if (true) {
-            //menuClose();
-            elementTimetable.classList.add("no");
-            elementDelay.classList.add("no");
-            setTimeout(function() {
-                elementFavorite.classList.remove("no");
-            }, 100);
-            setTimeout(() => {
-                menuOpen();
-            }, 0);
-        }
-        else {
+        elementTimetable.classList.add("no");
+        elementDelay.classList.add("no");
+        setTimeout(function() {
             elementFavorite.classList.remove("no");
-            elementTimetable.classList.add("no");
-            elementDelay.classList.add("no");
-            setTimeout(() => {
-                menuOpen();
-            }, 0);
-        }
-        elementMenu.classList.remove("closed");
+        }, 100);
+        menuOpen();
 
+        elementMenu.classList.remove("closed");
 
     }
     else { toggleMenu(); }
@@ -428,31 +409,17 @@ function toggleTimetable() {
     //If favorite is visible, close menus, change visibilites and toggle menu
     if (elementTimetable.classList.contains("no")) {
         //if (!elementMenu.classList.contains("closed")) {
-        if (true) {
-            //menuClose();
-            elementFavorite.classList.add("no");
-            setTimeout(() => {
-                elementTimetable.classList.remove("no");
-
-                if (delayContent.innerHTML != '\n\t\t\t') {
-                    elementDelay.classList.remove("no");
-                }
-
-            }, 100);
-            setTimeout(() => {
-                menuOpen();
-            }, 0);
-        }
-        else {
+        //menuClose();
+        elementFavorite.classList.add("no");
+        setTimeout(() => {
             elementTimetable.classList.remove("no");
-            elementFavorite.classList.add("no");
+
             if (delayContent.innerHTML != '\n\t\t\t') {
                 elementDelay.classList.remove("no");
             }
-            setTimeout(() => {
-                menuOpen();
-            }, 0);
-        }
+
+        }, 100);
+        menuOpen();
         elementMenu.classList.remove("closed");
 
     }

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -384,6 +384,8 @@ function toggleFavorite() {
         elementDelay.classList.add("no");
         setTimeout(function() {
             elementFavorite.classList.remove("no");
+            elementTimetable.classList.add("no");
+            elementDelay.classList.add("no");
         }, 100);
         menuOpen();
 
@@ -413,6 +415,7 @@ function toggleTimetable() {
         elementFavorite.classList.add("no");
         setTimeout(() => {
             elementTimetable.classList.remove("no");
+            elementFavorite.classList.add("no");
 
             if (delayContent.innerHTML != '\n\t\t\t') {
                 elementDelay.classList.remove("no");

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -523,12 +523,17 @@ function updateSearch(e) {
 
 SEARCH_RESULTS.addEventListener("click", function(e) {
     console.log(e);
+    // Close potentially open bus popups to prevent map auto-panning on location update
+    m2[currentBusId]?.closePopup();
     if (e.target.tagName === "LI") {
         displayBusStopsOnMap(e.target.dataset.busStopName);
     }
 });
 
 
+/**
+ * Handle keyboard selection of search results
+ */
 updownselectindex = 0;
 function updownselect(e) {
     console.log("updownselect: ", e);

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -119,7 +119,7 @@ async function addBusStops() {
     }
     ADDBUSSTOPCONTAINER.innerHTML = "";
 
-    let stops = Object.keys(busStops).filter(p => p.toLowerCase().includes(query.toLowerCase()));
+    let stops = Object.keys(busStops).sort().filter(p => p.toLowerCase().includes(query.toLowerCase()));
     for (let p of stops) {
         let button = document.createElement("span");
         button.classList.add("btn_busstop");
@@ -133,7 +133,7 @@ async function addBusStops() {
                 return;
             }
             ADDBUSSTOPCONTAINER.innerHTML = "";
-            let stops = Object.keys(busStops).filter(p => p.toLowerCase().includes(endPoint.toLowerCase()));
+            let stops = Object.keys(busStops).sort().filter(p => p.toLowerCase().includes(endPoint.toLowerCase()));
             for (let p of stops) {
                 let button = document.createElement("span");
                 button.classList.add("btn_busstop");
@@ -504,7 +504,7 @@ function updateSearch(e) {
     var search_results_container = document.getElementById("search_results_container");
     SEARCH_RESULTS.innerHTML = "";
     if (query.length >= 3) {
-        let stops = Object.keys(busStops).filter(p => p.toLowerCase().includes(query.toLowerCase()));
+        let stops = Object.keys(busStops).sort().filter(p => p.toLowerCase().includes(query.toLowerCase()));
         for (let p of stops) {
             let li = document.createElement("li");
             li.innerHTML = p;
@@ -565,6 +565,12 @@ function updownselect(e) {
             //updownselectindex = updownselectindex% shownResults.length;
     }
     shownResults[updownselectindex]?.classList.add("selected");
+    if(!!shownResults[updownselectindex]?.scrollIntoViewIfNeeded) {
+        shownResults[updownselectindex]?.scrollIntoViewIfNeeded(false);
+    } else {
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=403510
+        shownResults[updownselectindex]?.scrollIntoView({block: "center", container: "nearest" });
+    }
 }
 
 document.getElementById("search_field").addEventListener("input", updateSearch);

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -518,6 +518,7 @@ function updateSearch(e) {
         SEARCH_RESULTS.style.minHeight = "0";
         search_results_container.style.opacity = "0";
     }
+    updownselect();
 }
 
 SEARCH_RESULTS.addEventListener("click", function(e) {
@@ -528,7 +529,32 @@ SEARCH_RESULTS.addEventListener("click", function(e) {
 });
 
 
+updownselectindex = 0;
+function updownselect(e) {
+    console.log("updownselect: ", e);
+    let shownResults = document.getElementById("search_results").getElementsByTagName("li");
+    shownResults[updownselectindex]?.classList.remove("selected");
+    switch(e?.key) {
+        case "ArrowDown":
+            e.preventDefault();
+            updownselectindex = ++updownselectindex%shownResults.length;
+            break;
+        case "ArrowUp":
+            e.preventDefault();
+            updownselectindex = (--updownselectindex + shownResults.length)%shownResults.length;
+            break;
+        case "Enter":
+            shownResults[updownselectindex]?.click();
+            break;
+        default:
+            updownselectindex = 0;
+            //updownselectindex = updownselectindex% shownResults.length;
+    }
+    shownResults[updownselectindex]?.classList.add("selected");
+}
+
 document.getElementById("search_field").addEventListener("input", updateSearch);
+document.getElementById("search_container").addEventListener("keydown", updownselect);
 
 
 /**

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -66,7 +66,16 @@ async function printTimetable(trips) {
         td.appendChild(zeleniRelacijskiGumb);
         tr.appendChild(td);
         td = document.createElement("td");
-        td.innerText = `${Math.round((new Date(`${todayISO}T${seconds2time(t.endStopArrival)}`) - new Date(`${todayISO}T${seconds2time(t.departure_realtime ?? t.arrival_realtime)}`)) / 60000)} min`;
+
+        let HHmmss = seconds2time(t.endStopArrival).split(":");
+        let endStopArrivalDate = new Date(todayISO);
+        endStopArrivalDate.setHours(...HHmmss);
+        
+        HHmmss = seconds2time(t.departure_realtime ?? t.arrival_realtime).split(":");
+        let departureDate = new Date(todayISO);
+        departureDate.setHours(...HHmmss);
+
+        td.innerText = `${Math.round((endStopArrivalDate - departureDate) / 60000)} min`;
         tr.appendChild(td);
         td = document.createElement("td");
         // only fisrt 5 letters of operator name

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -128,49 +128,6 @@ async function addBusStops() {
     /* setLabel("<- Vstopna postaja", "Išči vstopno postajo"); */
     setLabel("Vstopna postaja:", "Išči vstopno postajo");
     searchSelectionType = "entry"; // Set selection type to entry bus stop
-/*     if (Object.keys(busStops).length === 0) {
-        await requestAllBusStops();
-    }
-    let query = prompt("Vnesi name vstopne postaje").trimEnd();
-    if (query.length < 3) {
-        alert("Vnesi vsaj 3 črke ... Upam, da nima kakšna postaja krajšega imena 😅");
-        return;
-    }
-    ADDBUSSTOPCONTAINER.innerHTML = "";
-
-    let stops = Object.keys(busStops).sort().filter(p => p.toLowerCase().includes(query.toLowerCase()));
-    for (let p of stops) {
-        let button = document.createElement("span");
-        button.classList.add("btn_busstop");
-        button.innerText = p;
-        button.onclick = () => {
-            entryBusStop = busStops[p];
-            entryBusStopName = p;
-            let endPoint = prompt("Vnesi name izstopne postaje");
-            if (endPoint.length < 3) {
-                alert("Vnesi vsaj 3 črke ... Upam, da nima kakšna postaja krajšega imena 😅");
-                return;
-            }
-            ADDBUSSTOPCONTAINER.innerHTML = "";
-            let stops = Object.keys(busStops).sort().filter(p => p.toLowerCase().includes(endPoint.toLowerCase()));
-            for (let p of stops) {
-                let button = document.createElement("span");
-                button.classList.add("btn_busstop");
-                button.innerText = p;
-                button.onclick = () => {
-                    exitBusStop = busStops[p];
-                    exitBusStopName = p;
-                    requestLineAllStops(entryBusStop, exitBusStop);
-                    saveBusLine(entryBusStop, exitBusStop, `${entryBusStopName}–${exitBusStopName}`)
-                    //Delete bus stop buttons after the relation has been added
-                    ADDBUSSTOPCONTAINER.innerHTML = "";
-                }
-                ADDBUSSTOPCONTAINER.appendChild(button);
-
-            }
-        }
-        ADDBUSSTOPCONTAINER.appendChild(button);
-    } */
 }
 
 /**
@@ -545,6 +502,7 @@ SEARCH_RESULTS.addEventListener("click", function(e) {
                 toggleSearch("close");
                 requestLineAllStops(entryBusStop, exitBusStop);
                 saveBusLine(entryBusStop, exitBusStop, `${vstopnaPostajaPriDodajanjuRelacije}–${izstopnaPostajaPriDodajanjuRelacije}`)
+                toast(`Relacija ${vstopnaPostajaPriDodajanjuRelacije}–${izstopnaPostajaPriDodajanjuRelacije} je bila shranjena med priljubljene.`)
                 break
             case "search":
             default:

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -103,7 +103,7 @@ async function addBusStops() {
     if (Object.keys(busStops).length === 0) {
         await requestAllBusStops();
     }
-    let query = prompt("Vnesi name vstopne postaje");
+    let query = prompt("Vnesi name vstopne postaje").trimEnd();
     if (query.length < 3) {
         alert("Vnesi vsaj 3 črke ... Upam, da nima kakšna postaja krajšega imena 😅");
         return;
@@ -687,6 +687,8 @@ const busId = urlParams.get('busId'); // e.g., https://link?busId=123
 document.addEventListener("DOMContentLoaded", function() {
     if (busId) {
         displayBus(busId);
+    } else {
+        toggleFavorite();
     }
 
     // TODO: Make this a beautiful tooltip

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -130,6 +130,16 @@ async function addBusStops() {
     searchSelectionType = "entry"; // Set selection type to entry bus stop
 }
 
+function labelClick() {
+    if(searchSelectionType === "exit") {
+        document.getElementById("search_field").value = vstopnaPostajaPriDodajanjuRelacije;
+        setLabel("Vstopna postaja:", "Išči vstopno postajo");
+        searchSelectionType = "entry";
+        const event = new Event("input");
+        document.getElementById("search_field").dispatchEvent(event);
+    }
+}
+
 /**
  * Draw favorite relation buttons
  * @param {*} buttons Array of all buttons

--- a/style.css
+++ b/style.css
@@ -967,3 +967,10 @@ input[type='text']{
     pointer-events: none;
     opacity: 0.4;
 }
+
+.selected::before {
+    content: "🟡 ";
+}
+.selected {
+    font-weight: bold;
+}

--- a/style.css
+++ b/style.css
@@ -13,6 +13,10 @@
     --color-theme-second: rgba(204, 204, 204, 0.69);
     --color-toast: #ecca9e;
     --color-live: #4f6f52;
+    
+    --slide-animation:    transform 0.18s -0.1s cubic-bezier(0, 0, 0.2, 1), opacity 0.08s 0s cubic-bezier(0, 0, 0.2, 1), display 0.08s 0s cubic-bezier(0, 0, 0.2, 1) allow-discrete;
+    --slide-in-animation: transform 0.18s 0s    cubic-bezier(0, 0, 0.2, 1), opacity 0.08s 0s cubic-bezier(0, 0, 0.2, 1), display 0.08s 0s cubic-bezier(0, 0, 0.2, 1) allow-discrete;
+    --slide-amount: 3rem;
 
     overscroll-behavior: none;
 }
@@ -91,6 +95,38 @@ button:not(.zamudas button) {
 
 /*Containers*/
 
+/* The transitions work nicely (both ways) in Chrome. For unknown reason, fading out with display: none and allow-discrete happens instantaniously in Firefox. (It fades in correctly) */
+#favorites {
+    transform: translateX(0);
+    opacity: 1;
+    transition: var(--slide-animation);
+    @starting-style {
+        opacity: 0;
+        transform: translateX(calc(-1 * var(--slide-amount)));
+
+      }
+}
+#favorites.no {
+ transform: translateX(calc(-1 * var(--slide-amount)));
+    opacity: 0;
+    transition: var(--slide-in-animation);
+}
+
+#timetable_container {
+    transform: translateX(0);
+    opacity: 1;
+    transition: var(--slide-animation);
+    @starting-style {
+        opacity: 0;
+        transform: translateX(var(--slide-amount));
+
+      }
+}
+#timetable_container.no {
+ transform: translateX(var(--slide-amount));
+    opacity: 0;
+    transition: var(--slide-in-animation);
+}
 
 .site_container{
     min-height: 350px;
@@ -307,7 +343,7 @@ input:-webkit-autofill {
 }
 
 #search_results li{
-    width: fit-content;
+    /* width: fit-content; */
     list-style-type: none;
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;
@@ -973,4 +1009,8 @@ input[type='text']{
 }
 .selected {
     font-weight: bold;
+}
+
+#search_results_container li:hover {
+    background-color: var(--color-theme-second);
 }

--- a/style.css
+++ b/style.css
@@ -286,11 +286,12 @@ button:not(.zamudas button) {
 
 }
 #search_field{
-    position: relative;
+/*     position: relative; */
     font-family: 'Open Sans', sans-serif;
     background-color: var(--color-theme);
     width:70%;
-    left:10px;
+    /* left:10px; */
+    margin-left: 10px;
     border:none;
     text-align: left;
     z-index: 5;
@@ -302,9 +303,10 @@ input:-webkit-autofill {
 }
 
 #search_logo{
-    position: absolute;
+    /* position: absolute; */
+    position: relative;
     right: 20px;
-    transform: translate(0, 60%);
+    /* transform: translate(0, 60%); */
     font-size: 2em;
     color: var(--color-primary);
     z-index: 5;	
@@ -903,7 +905,7 @@ input[type='text']{
     border-bottom: 2px solid var(--color-primary);
     width: 60%;
     padding: 0.5rem 1rem;
-    margin-left: auto;
+/*     margin-left: auto; */
     margin-right: auto;
     margin-block-end: 10px;
     margin-block-start: 10px;
@@ -1013,4 +1015,16 @@ input[type='text']{
 
 #search_results_container li:hover {
     background-color: var(--color-theme-second);
+}
+
+#label_search_field {
+    z-index: 6;
+/*     position: absolute;
+    right: 2rem;
+    top: 1.1rem; */
+    background-color: var(--color-theme-second);
+    height: 50px; /* Always set to same as element search_container */
+    border-radius: 25px 0 0 25px;
+    display: flex;
+    align-items: center;
 }


### PR DESCRIPTION
This PR fixes #17 and fixes #13.
It adds keyboard (arrow keys) selection of search results to close #14 

Additionally, it denotes train stations by 🚂 emoji to allow for easier differentiation of bus and train stops. Note: some stations are now split into 2 different results (e. g. Trzin Mlake and Trzin Mlake 🚂)!

Furthermore, search results are now ordered alphabetically.

When user opens the app, the "Priljubljene" tab is now opened automatically. This should improve UX for first-time users. 


TODO: 
- [x] Use the new search view instead of the old buttons when adding new priljubljene relacije
- [x] Bump version
