### PR TITLE
Fix time calculation issues, handle Device Back Button

### DIFF
--- a/busi-offline.js
+++ b/busi-offline.js
@@ -1,5 +1,5 @@
 {
-	"version": "2.2.3",
+	"version": "2.2.4",
 	"fileList": [
 		"index.html",
 		"style.css",

--- a/scripts/api_calls.js
+++ b/scripts/api_calls.js
@@ -1,6 +1,6 @@
 const apiUrl = 'https://api.beta.brezavta.si';
-var today = new Date().toISOString().slice(0,10).replaceAll("-", "");
-var todayISO = new Date().toISOString().slice(0,10);
+var todayISO = new Date().toLocaleDateString("sv");
+var today = todayISO.replaceAll("-", "");
 var noLoaders = 0;
 
 

--- a/scripts/backend.js
+++ b/scripts/backend.js
@@ -89,6 +89,9 @@ async function showBuses(automatic = false, allBuses = false) {
  * @param {*} automatic True if called automatically
  */
 async function refresh(automatic = false, tripId = undefined) {
+    // In rare cases of running the app overnight, we need to update the date
+    todayISO = new Date().toLocaleDateString("sv");
+    today = todayISO.replaceAll("-", "");
 
     if (selectedStop) {
         await displayTripsOnStop(selectedStop, 300);

--- a/scripts/backend.js
+++ b/scripts/backend.js
@@ -225,7 +225,6 @@ function getTimeAsDate(timeString) {
  * @param {int} id id of the bus stop (properties.id)
  */
 async function checkDepartures(id) {
-    console.log(id);
     removeMarkers(); // We want to hide all other buses
     await displayTripsOnStop(id, 300);
     refresh(automatic=true);


### PR DESCRIPTION
This PR fixes time calculation issues. It also correctly handles the Android Device Back Button on Firefox. 

The behaviour in Chrome is not consistent and changes depending on how the user accessed the website (clicking a link, typing in a link from a blank tab, typing in a link from an open tab ...). It appears that user interaction (touching either the website content or the DevTools) is required each time after pressing the Back Button, otherwise it just closes on second Back Button press. However, sometimes it closes despite user interaction. And sometimes (on desktop, at least), it doesn't close despite lack of user interaction. #23 

Further area to research: changing href to `#something`. This seems to correctly navigate the history. However, on every href change, something weird happens (e. g. pannels closing as soon as they open, because we landed on a "different page". I suppose it _might_ trigger the DOM_loaded/content_ready event, which is indeed supposed to close pannels in our code).