### PR TITLE
Make params shorter

### DIFF
--- a/busi-offline.js
+++ b/busi-offline.js
@@ -1,5 +1,5 @@
 {
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"fileList": [
 		"index.html",
 		"style.css",

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -639,7 +639,7 @@ function displayBusStopsOnMap(busStopName) {
                 menuClose();
                 toggleTimetable();
 
-                document.getElementById('timetable_title').innerHTML = busStop.name;
+                document.getElementById('timetable_title').innerHTML = busStopName;
                 document.getElementById('timetable_warning').classList.add("no");
             });
 
@@ -649,7 +649,7 @@ function displayBusStopsOnMap(busStopName) {
                 menuClose();
             });
 
-            let content = `<span style="color:var(--color-primary)">${busStop.name}</span>`;
+            let content = `<span style="color:var(--color-primary)">${busStopName}</span>`;
             marker.bindPopup(content);
             // Fly to
             mymap.flyTo([lat, lon], 18.5, { duration: 0.5 });

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -732,8 +732,8 @@ function fadeOut(elementID, time) {
 // Get the busId from the URL
 const urlParams = new URLSearchParams(window.location.search);
 const busId = urlParams.get('busId'); // e.g., https://link?busId=123
-const stationName = urlParams.get('stationName'); // e.g., https://link?stationName=Central+Station
-const busStopId = urlParams.get('busStopId'); // e.g., https://link?busStopId=456
+const stationName = urlParams.get('s'); // e.g., https://link?stationName=Central+Station
+const busStopId = urlParams.get('i'); // e.g., https://link?busStopId=456
 // Maybe we could also add array busStopsId = urlParams.getAll('busStopId'); // e.g., https://link?busStopId=456&busStopId=789
 
 /* !!! IMPORTANT !!!


### PR DESCRIPTION
This PR makes query params shorter to allow for smaller QR-codes to be generated. 

Additionally, it fixes missing 🚂 when looking for departures from a train station.