### PR TITLE
Make invisible markers invisible to fix #41

### DIFF
--- a/busi-offline.js
+++ b/busi-offline.js
@@ -1,5 +1,5 @@
 {
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"fileList": [
 		"index.html",
 		"style.css",

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -381,8 +381,8 @@ async function drawBuses(buses, automatic = false, fitView = false) {
                 //Make all other visible markers more transparent
                 for (let m in m2) {
                     if (m !== currentBusId){
-                        m2[m].setOpacity(0);
-                        m3[m].setOpacity(0);
+                        m2[m].getElement().classList.add("hidden");
+                        m3[m].getElement().classList.add("hidden");
                     }
                 }
 
@@ -403,8 +403,8 @@ async function drawBuses(buses, automatic = false, fitView = false) {
 
                 //Restore opacity
                 for (let m in m2) {
-                    m2[m].setOpacity(1);
-                    m3[m].setOpacity(1);
+                    m2[m].getElement().classList.remove("hidden");
+                    m3[m].getElement().classList.remove("hidden");
                 }
 
                 //Reset global variable

--- a/style.css
+++ b/style.css
@@ -1111,3 +1111,8 @@ input[type='text'] {
         display: block;
     }
 }
+
+.hidden {
+    /* These are not clickable/holdable/hoverable on Firefox and Chrome */
+    visibility: hidden;
+}


### PR DESCRIPTION
Using `visibility: hidden;` is enough for Firefox to make the marker unclickable/unholdoverable.